### PR TITLE
Fix bulk ops by

### DIFF
--- a/backend/db/repositories/document.dao.ts
+++ b/backend/db/repositories/document.dao.ts
@@ -45,7 +45,7 @@ export class DocumentDao<T extends Entity> {
     const ops = objs.map((obj: any) => {
       //Ensure item is a model, to allow inclusion of default values
       if (!(obj instanceof this.Model)) {
-        obj = new this.Model(obj);
+        obj = new this.Model({_id: new mongoose.Types.ObjectId(obj.id), obj });
       }
       // Convert to plain object
       if (obj instanceof this.Model) {

--- a/backend/db/repositories/document.dao.ts
+++ b/backend/db/repositories/document.dao.ts
@@ -73,7 +73,7 @@ export class DocumentDao<T extends Entity> {
     const ops = objs.map((obj: any) => {
       //Ensure item is a model, to allow inclusion of default values
       if (!(obj instanceof this.Model)) {
-        obj = new this.Model(obj);
+        obj = new this.Model({ _id: new mongoose.Types.ObjectId(obj.id), ...obj });
       }
       // Convert to plain object
       if (obj instanceof this.Model) {

--- a/backend/db/repositories/document.dao.ts
+++ b/backend/db/repositories/document.dao.ts
@@ -45,7 +45,7 @@ export class DocumentDao<T extends Entity> {
     const ops = objs.map((obj: any) => {
       //Ensure item is a model, to allow inclusion of default values
       if (!(obj instanceof this.Model)) {
-        obj = new this.Model({_id: new mongoose.Types.ObjectId(obj.id), obj });
+        obj = new this.Model({ _id: new mongoose.Types.ObjectId(obj.id), obj });
       }
       // Convert to plain object
       if (obj instanceof this.Model) {


### PR DESCRIPTION
### Description
When _id is not provided eg when working with a submitted model, _id is auto creating when creating a new model, meaning the filter doesn't match. This is a fix to that. 