### PR TITLE
Refactor fail error

### DIFF
--- a/backend/app/api/RequestHandler.ts
+++ b/backend/app/api/RequestHandler.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express';
 import { Request as JWTRequest } from 'express-jwt';
 import createHttpError, { HttpError } from 'http-errors';
-import { isEmpty, startCase } from 'lodash';
 
 import { AppError } from './common/AppError.js';
 import * as constants from './common/constants.js';

--- a/backend/app/api/RequestHandler.ts
+++ b/backend/app/api/RequestHandler.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { Request as JWTRequest } from 'express-jwt';
 import createHttpError, { HttpError } from 'http-errors';
+import { isEmpty, startCase } from 'lodash';
 
 import { AppError } from './common/AppError.js';
 import * as constants from './common/constants.js';
@@ -29,7 +30,7 @@ export default class RequestHandler {
     if (error.isFailure) {
       const appError = error.unwrap() as AppError;
       const httpError = this.makeHttpError(appError);
-      this.errorHandler(httpError, appError, error.message);
+      this.errorHandler(httpError, appError, error.reason);
     } else {
       this.errorHandler(error);
     }
@@ -55,8 +56,8 @@ export default class RequestHandler {
     console.log('Error-Cause ', appError?.cause ?? error.cause ?? 'N/A');
     this.res.status(error.status ?? 500);
     this.res.send({
-      msg: error.msg ?? error.message,
-      reason: failReason ?? 'Something went wrong',
+      message: error.message,
+      reason: failReason,
       validationErrors: appError?.validationErrors,
     });
   }

--- a/backend/app/api/auth/useCases/authenticateUserUseCase.ts
+++ b/backend/app/api/auth/useCases/authenticateUserUseCase.ts
@@ -48,8 +48,7 @@ export class AuthenticateUserUseCase {
 
       if (!foundUser) {
         throw Result.fail(
-          AppError.validationFailed('username or password is invalid'),
-          'Bad Request'
+          AppError.validationFailed('username or password is invalid')
         );
       }
 
@@ -60,8 +59,7 @@ export class AuthenticateUserUseCase {
 
       if (!isPasswordValid) {
         throw Result.fail(
-          AppError.validationFailed('username or password is invalid'),
-          'Bad Request'
+          AppError.validationFailed('username or password is invalid')
         );
       }
 

--- a/backend/app/api/common/AppError.ts
+++ b/backend/app/api/common/AppError.ts
@@ -29,11 +29,11 @@ export class AppError extends Error {
     this.validationErrors = validationErrors;
   }
 
-  static createError(name: string, message?: string, cause?: Error) {
+  static create(name: string, message?: string, cause?: Error) {
     return new AppError({ cause, message, name });
   }
 
-  static createNotFoundError(message: string) {
+  static resourceNotFound(message: string) {
     return new AppError({
       code: constants.ERR_VALUE_NOT_FOUND,
       message,
@@ -41,15 +41,15 @@ export class AppError extends Error {
     });
   }
 
-  static createValidationError(
-    message: string,
+  static validationFailed(
+    message: string | ValidationMessage[],
     validationErrors?: ValidationMessage[]
   ) {
     return new AppError({
       code: constants.ERR_VALIDATION,
-      message,
-      name: 'validation-errors',
-      validationErrors,
+      message: typeof message === 'string' ? message : 'Validation failed',
+      name: 'bad-request',
+      validationErrors: Array.isArray(message) ? message : validationErrors,
     });
   }
 }

--- a/backend/app/api/common/result/mod.ts
+++ b/backend/app/api/common/result/mod.ts
@@ -43,7 +43,7 @@ export class FailureResult<E extends Error>
       ? this.message
       : cause && cause instanceof Error && cause.name
         ? startCase(cause.name)
-        : null;
+        : 'Something went wrong';
   }
 
   readonly isSuccess = false;

--- a/backend/app/api/common/result/mod.ts
+++ b/backend/app/api/common/result/mod.ts
@@ -1,3 +1,5 @@
+import { startCase } from 'lodash';
+
 export type Result<T = unknown, E extends Error = Error> =
   | SuccessResult<T>
   | FailureResult<E>;
@@ -33,6 +35,15 @@ export class FailureResult<E extends Error>
 
   get value() {
     return undefined;
+  }
+
+  get reason() {
+    const cause = this.cause;
+    return typeof this.message === 'string' && this.message.length > 0
+      ? this.message
+      : cause && cause instanceof Error && cause.name
+        ? startCase(cause.name)
+        : null;
   }
 
   readonly isSuccess = false;

--- a/backend/app/api/common/validation/validatorWrapper.ts
+++ b/backend/app/api/common/validation/validatorWrapper.ts
@@ -26,7 +26,7 @@ export class JoiValidator implements Validator {
       const FIRST_ERROR = 0;
       const errorMessage = error.details[FIRST_ERROR].message;
       return Result.fail(
-        AppError.createValidationError(errorMessage.replace(/"/g, "'"))
+        AppError.validationFailed(errorMessage.replace(/"/g, "'"))
       );
     }
   }

--- a/backend/app/api/data/competitions/useCases/getCompetition.useCase.ts
+++ b/backend/app/api/data/competitions/useCases/getCompetition.useCase.ts
@@ -29,10 +29,9 @@ export default class GetCompetitionUseCase {
 
       if (!foundCompetition) {
         throw Result.fail(
-          AppError.createNotFoundError(
+          AppError.resourceNotFound(
             `Could not find competition with slug ${slug}`
-          ),
-          'Resource Not Found'
+          )
         );
       }
       this.responder.respond(foundCompetition);
@@ -41,7 +40,7 @@ export default class GetCompetitionUseCase {
         throw err;
       }
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Competition could not be fetched',
           err

--- a/backend/app/api/data/competitions/useCases/getCompetitions.useCase.ts
+++ b/backend/app/api/data/competitions/useCases/getCompetitions.useCase.ts
@@ -34,7 +34,7 @@ export default class GetCompetitionsUseCase {
       }
 
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Competitions could not be fetched',
           err

--- a/backend/app/api/data/matches/useCases/getRoundMatch.useCase.ts
+++ b/backend/app/api/data/matches/useCases/getRoundMatch.useCase.ts
@@ -81,10 +81,7 @@ export default class GetRoundMatchUseCase {
 
       if (!foundMatch) {
         throw Result.fail(
-          AppError.createNotFoundError(
-            `Could not find Match with slug ${slug}`
-          ),
-          'Resource Not Found'
+          AppError.resourceNotFound(`Could not find Match with slug ${slug}`)
         );
       }
       this.responder.respond(foundMatch);
@@ -93,7 +90,7 @@ export default class GetRoundMatchUseCase {
         throw err;
       }
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Round-Match could not be fetched',
           err

--- a/backend/app/api/data/matches/useCases/getRoundMatches.useCase.ts
+++ b/backend/app/api/data/matches/useCases/getRoundMatches.useCase.ts
@@ -63,7 +63,6 @@ export default class GetRoundMatchesUseCase {
       const foundSeason = await validator.validateSeason(competition, season);
       const foundRound = await validator.validateRound(foundSeason.id!, round);
 
-      console.log('foundR', foundRound);
       const foundMatches = await lastValueFrom(
         this.matchRepo.findAll$({ gameRound: foundRound.id }, '-createdAt')
       );
@@ -74,7 +73,7 @@ export default class GetRoundMatchesUseCase {
       }
 
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Round-Matches could not be fetched',
           err

--- a/backend/app/api/data/matches/useCases/getSeasonMatch.useCase.ts
+++ b/backend/app/api/data/matches/useCases/getSeasonMatch.useCase.ts
@@ -66,10 +66,7 @@ export default class GetSeasonMatchUseCase {
 
       if (!foundMatch) {
         throw Result.fail(
-          AppError.createNotFoundError(
-            `Could not find Match with slug ${slug}`
-          ),
-          'Resource Not Found'
+          AppError.resourceNotFound(`Could not find Match with slug ${slug}`)
         );
       }
       this.responder.respond(foundMatch);
@@ -78,7 +75,7 @@ export default class GetSeasonMatchUseCase {
         throw err;
       }
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Season-Match could not be fetched',
           err

--- a/backend/app/api/data/matches/useCases/getSeasonMatches.useCase.ts
+++ b/backend/app/api/data/matches/useCases/getSeasonMatches.useCase.ts
@@ -63,7 +63,7 @@ export default class GetSeasonMatchesUseCase {
       }
 
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Season-Matches could not be fetched',
           err

--- a/backend/app/api/data/rounds/useCases/getRound.useCase.ts
+++ b/backend/app/api/data/rounds/useCases/getRound.useCase.ts
@@ -66,10 +66,7 @@ export default class GetRoundUseCase {
 
       if (!foundRound) {
         throw Result.fail(
-          AppError.createNotFoundError(
-            `Could not find Round with slug ${slug}`
-          ),
-          'Resource Not Found'
+          AppError.resourceNotFound(`Could not find Round with slug ${slug}`)
         );
       }
       this.responder.respond(foundRound);
@@ -78,7 +75,7 @@ export default class GetRoundUseCase {
         throw err;
       }
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Competition-Season could not be fetched',
           err

--- a/backend/app/api/data/rounds/useCases/getRounds.useCase.ts
+++ b/backend/app/api/data/rounds/useCases/getRounds.useCase.ts
@@ -63,7 +63,7 @@ export default class GetRoundsUseCase {
       }
 
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Season-Rounds could not be fetched',
           err

--- a/backend/app/api/data/seasonTeams/useCases/getSeasonTeams.useCase.ts
+++ b/backend/app/api/data/seasonTeams/useCases/getSeasonTeams.useCase.ts
@@ -54,7 +54,7 @@ export default class GetSeasonTeamsUseCase {
       }
 
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'SeasonTeams could not be fetched',
           err

--- a/backend/app/api/data/seasons/useCases/getSeason.useCase.ts
+++ b/backend/app/api/data/seasons/useCases/getSeason.useCase.ts
@@ -45,10 +45,7 @@ export default class GetSeasonUseCase {
 
       if (!foundSeason) {
         throw Result.fail(
-          AppError.createNotFoundError(
-            `Could not find Season with slug ${slug}`
-          ),
-          'Resource Not Found'
+          AppError.resourceNotFound(`Could not find Season with slug ${slug}`)
         );
       }
       this.responder.respond(foundSeason);
@@ -57,7 +54,7 @@ export default class GetSeasonUseCase {
         throw err;
       }
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Competition-Season could not be fetched',
           err

--- a/backend/app/api/data/seasons/useCases/getSeasons.useCase.ts
+++ b/backend/app/api/data/seasons/useCases/getSeasons.useCase.ts
@@ -44,7 +44,7 @@ export default class GetSeasonsUseCase {
       }
 
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Competition-Seasons could not be fetched',
           err

--- a/backend/app/api/data/teams/useCases/getTeam.useCase.ts
+++ b/backend/app/api/data/teams/useCases/getTeam.useCase.ts
@@ -27,8 +27,7 @@ export default class GetTeamUseCase {
 
       if (!foundTeam) {
         throw Result.fail(
-          AppError.createNotFoundError(`Could not find team with slug ${slug}`),
-          'Resource Not Found'
+          AppError.resourceNotFound(`Could not find team with slug ${slug}`)
         );
       }
       this.responder.respond(foundTeam);
@@ -37,7 +36,7 @@ export default class GetTeamUseCase {
         throw err;
       }
       throw Result.fail(
-        AppError.createError('fetch-failed', 'Team could not be fetched', err),
+        AppError.create('fetch-failed', 'Team could not be fetched', err),
         'Internal Server Error'
       );
     }

--- a/backend/app/api/data/teams/useCases/getTeams.useCase.ts
+++ b/backend/app/api/data/teams/useCases/getTeams.useCase.ts
@@ -32,7 +32,7 @@ export default class GetTeamsUseCase {
       }
 
       throw Result.fail(
-        AppError.createError(
+        AppError.create(
           'fetch-failed',
           'Competitions could not be fetched',
           err

--- a/backend/app/api/data/useCase.validators.ts
+++ b/backend/app/api/data/useCase.validators.ts
@@ -26,10 +26,7 @@ export const makeGetSeasonsValidator = (
         },
       ];
 
-      throw Result.fail(
-        AppError.createValidationError('Bad data', errors),
-        'Bad Request'
-      );
+      throw Result.fail(AppError.validationFailed(errors));
     },
   };
 };
@@ -49,7 +46,7 @@ const makeGetSeasonResourcesValidator = (
 
       if (!foundSeason) {
         throw Result.fail(
-          AppError.createValidationError('Bad data', [
+          AppError.validationFailed('Bad data', [
             {
               msg: `No Competition-Season with slug ${season}`,
               param: 'season',
@@ -82,7 +79,7 @@ export const makeGetSeasonTeamsValidator = (
 
       if (!foundSeason) {
         throw Result.fail(
-          AppError.createValidationError('Bad data', [
+          AppError.validationFailed('Bad data', [
             {
               msg: `No Competition-Season with slug ${season}`,
               param: 'season',
@@ -111,7 +108,7 @@ export const makeGetMatchesValidator = (
     validateRound: async (seasonId: string, round: string) => {
       if (!roundRepo) {
         throw Result.fail(
-          AppError.createError(
+          AppError.create(
             'validation-failed',
             'Round repository is not provided'
           ),
@@ -125,7 +122,7 @@ export const makeGetMatchesValidator = (
 
       if (!foundRound) {
         throw Result.fail(
-          AppError.createValidationError('Bad data', [
+          AppError.validationFailed('Bad data', [
             {
               msg: `No Season-Round with slug ${round}`,
               param: 'round',

--- a/backend/db/repositories/leaderboard.repo.ts
+++ b/backend/db/repositories/leaderboard.repo.ts
@@ -69,7 +69,7 @@ export class LeaderboardRepositoryImpl
     }).pipe(
       mergeMap(p => (p ? of(p) : EMPTY)),
       throwIfEmpty(() =>
-        AppError.createNotFoundError(`leaderboard:${leaderboardId}`)
+        AppError.resourceNotFound(`leaderboard:${leaderboardId}`)
       )
     );
   }

--- a/backend/db/repositories/prediction.repo.ts
+++ b/backend/db/repositories/prediction.repo.ts
@@ -349,7 +349,7 @@ export class PredictionRepositoryImpl
     choice: Score
   ): Observable<Prediction | null> {
     if (match.status !== MatchStatus.SCHEDULED) {
-      return throwError(() => AppError.createError('Match not scheduled'));
+      return throwError(() => AppError.create('Match not scheduled'));
     }
     const matchId = match.id!;
     return this.findOneByUserAndMatch$(userId, matchId).pipe(
@@ -368,9 +368,7 @@ export class PredictionRepositoryImpl
       }),
       mergeMap(prediction => {
         if (!prediction) {
-          return throwError(() =>
-            AppError.createError('Prediction does not exist')
-          );
+          return throwError(() => AppError.create('Prediction does not exist'));
         }
         return this.findByIdAndUpdate$(prediction.id!, {
           choice: { ...choice, isComputerGenerated: false },

--- a/backend/db/repositories/userScore.repo.ts
+++ b/backend/db/repositories/userScore.repo.ts
@@ -140,7 +140,7 @@ export class UserScoreRepositoryImpl
           }).pipe(
             mergeMap(s => (s ? of(s) : EMPTY)),
             throwIfEmpty(() =>
-              AppError.createError(`userscore: ${String(userScore.id)}`)
+              AppError.create(`userscore: ${String(userScore.id)}`)
             )
           );
         }


### PR DESCRIPTION
- in usecases, the idea is to do `throw Result.fail AppError` i.e fail the request processing with an app error -- in none-usecase methods we can use AppError.create or just throw another error (not recommended)
- todo move AppError cause it is going be pervasive